### PR TITLE
Update WebflowOAuth2Api.credentials.ts

### DIFF
--- a/packages/nodes-base/credentials/WebflowOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/WebflowOAuth2Api.credentials.ts
@@ -41,7 +41,7 @@ export class WebflowOAuth2Api implements ICredentialType {
 			displayName: 'Scope',
 			name: 'scope',
 			type: 'hidden',
-			default: '={{$self["legacy"] ? "" : "cms:read cms:write sites:read"}}',
+			default: '={{$self["legacy"] ? "" : "cms:read cms:write sites:read forms:read"}}',
 		},
 		{
 			displayName: 'Auth URI Query Parameters',


### PR DESCRIPTION
## Summary

Added the forms:read parameter to the scope, which was missing when legacy mode was unchecked. This caused the form submission functionality to stop working. 

## Related Linear tickets, Github issues, and Community forum posts

Issue https://github.com/n8n-io/n8n/issues/10549

## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
